### PR TITLE
Fixed invalid date that breaks the repo

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -84,7 +84,7 @@ entries:
       - https://github.com/nabsul/kcert/releases/download/v1.1.0/kcert-1.0.0.tgz
       version: 1.0.0
   kcert-ingress:
-    - created: "2022-12-27:00:00Z"
+    - created: "2022-12-27T00:00:00Z"
       description: "Create a KCert Certificate using a Ingress"
       home: https://github.com/nabsul/kcert
       name: kcert


### PR DESCRIPTION
A date was missing "T00" and was preventing helm to add the repo with the following error:
```
Error: looks like "https://nabsul.github.io/helm" is not a valid chart repository or cannot be reached: error unmarshaling JSON: while decoding JSON: parsing time "\"2022-12-27:00:00Z\"" as "\"2006-01-02T15:04:05Z07:00\"": cannot parse ":00:00Z\"" as "T"
```